### PR TITLE
feat(central-server,web-client)!: add refresh token support

### DIFF
--- a/CentralServer/README.md
+++ b/CentralServer/README.md
@@ -115,9 +115,9 @@ and can be used to pass additional SQLAlchemy connection arguments.
       "filepath": "database.db",
       "connect_args": {
         // SQLAlchemy connection arguments
-      }
-    }
-  }
+      },
+    },
+  },
   /* ... */
 }
 ```
@@ -286,3 +286,13 @@ containerized environment using Docker or Podman.
      /* ... */
    }
    ```
+
+#### Central Server Environment Variables
+
+The following environment variables are used by the central server
+to further configure its behavior. These variables are optional.
+
+| Environment Variable             | Value         | Description                                |
+| -------------------------------- | ------------- | ------------------------------------------ |
+| `CENTRAL_SERVER_CONFIG_FILE`     | ./config.json | The path of the configuration file to use. |
+| `CENTRAL_SERVER_CONFIG_ENCODING` | utf-8         | The encoding of the configuration file.    |

--- a/CentralServer/centralserver/info.py
+++ b/CentralServer/centralserver/info.py
@@ -7,7 +7,7 @@ class Program:
     """General program information."""
 
     name: Final[str] = "Project SCARS Central Server"
-    version: Final[tuple[int, int, int]] = (0, 3, 0)
+    version: Final[tuple[int, int, int]] = (0, 3, 4)
 
 
 class Database:

--- a/CentralServer/centralserver/internals/adapters/config.py
+++ b/CentralServer/centralserver/internals/adapters/config.py
@@ -7,7 +7,7 @@ from typing import Any, override
 
 
 class DatabaseAdapterConfig(ABC):
-    """Superclass for database adapter configuration."""
+    """Superclass for database adapter configurations."""
 
     @property
     @abstractmethod
@@ -140,7 +140,7 @@ class MySQLDatabaseConfig(DatabaseAdapterConfig):
 
 
 class ObjectStoreAdapterConfig(ABC):
-    """Adapter configuration for object store."""
+    """Superclass for object store configurations."""
 
     @property
     @abstractmethod

--- a/CentralServer/centralserver/internals/auth_handler.py
+++ b/CentralServer/centralserver/internals/auth_handler.py
@@ -30,6 +30,10 @@ def get_user(user_id: str, session: Session, by_id: bool = True) -> User | None:
         The user object if found, None otherwise.
     """
 
+    logger.debug(
+        "Getting user with ID: %s" if by_id else "Getting user with username: %s",
+        user_id,
+    )
     return (
         session.exec(select(User).where(User.id == user_id)).first()
         if by_id
@@ -48,6 +52,7 @@ def get_role(role_id: int, session: Session) -> Role | None:
         The Role object.
     """
 
+    logger.debug("Getting role with ID: %s", role_id)
     return session.get(Role, role_id)
 
 
@@ -63,6 +68,14 @@ def get_user_role(user_id: str, session: Session, by_id: bool = True) -> Role | 
         The ID of the role of the user.
     """
 
+    logger.debug(
+        (
+            "Getting role for user with ID: %s"
+            if by_id
+            else "Getting role for user with username: %s"
+        ),
+        user_id,
+    )
     return session.exec(
         select(Role).where(
             Role.id

--- a/CentralServer/centralserver/internals/logger.py
+++ b/CentralServer/centralserver/internals/logger.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 from time import strftime
 
@@ -119,3 +120,4 @@ def log_app_info(logger: logging.Logger):
     logger.debug(f"{app_config.security.allow_credentials=}")
     logger.debug(f"{app_config.security.allow_methods=}")
     logger.debug(f"{app_config.security.allow_headers=}")
+    logger.debug(f"Environment Variables:\n\n{os.environ}")

--- a/CentralServer/centralserver/internals/models.py
+++ b/CentralServer/centralserver/internals/models.py
@@ -16,6 +16,7 @@ class DefaultRole:
 class JWTToken(SQLModel):
     """A model representing a JWT token."""
 
+    uid: uuid.UUID
     access_token: str
     token_type: str
 

--- a/CentralServer/centralserver/internals/user_handler.py
+++ b/CentralServer/centralserver/internals/user_handler.py
@@ -145,14 +145,20 @@ def update_user_avatar(
 
     object_store_manager = get_object_store_handler(app_config.object_store)
     if img is None:
+        logger.debug("Deleting avatar for user: %s", target_user)
         if selected_user.avatarUrn is None:
+            logger.warning("No avatar to delete for user: %s", target_user)
             raise ValueError("No avatar to delete.")
 
         object_store_manager.delete(BucketNames.AVATARS, selected_user.avatarUrn)
         selected_user.avatarUrn = None
 
     else:
+        logger.debug("Updating avatar for user: %s", target_user)
         object = object_store_manager.put(BucketNames.AVATARS, selected_user.id, img)
+        if selected_user.avatarUrn is not None:  # Delete old avatar if it exists
+            object_store_manager.delete(BucketNames.AVATARS, selected_user.avatarUrn)
+
         selected_user.avatarUrn = object.fn
 
     selected_user.lastModified = datetime.datetime.now(datetime.timezone.utc)
@@ -181,6 +187,7 @@ def update_user_info(target_user: UserUpdate, session: Session) -> UserPublic:
         )
 
     if target_user.username:  # Update username if provided
+        logger.debug("Updating username for user: %s", target_user.id)
         # Check username availability
         if target_user.username != selected_user.username:
             try:
@@ -213,18 +220,23 @@ def update_user_info(target_user: UserUpdate, session: Session) -> UserPublic:
         selected_user.username = target_user.username
 
     if target_user.email:  # Update email if provided
+        logger.debug("Updating email for user: %s", target_user.id)
         selected_user.email = target_user.email
 
     if target_user.nameFirst:  # Update first name if provided
+        logger.debug("Updating first name for user: %s", target_user.id)
         selected_user.nameFirst = target_user.nameFirst
 
     if target_user.nameMiddle:  # Update middle name if provided
+        logger.debug("Updating middle name for user: %s", target_user.id)
         selected_user.nameMiddle = target_user.nameMiddle
 
     if target_user.nameLast:  # Update last name if provided
+        logger.debug("Updating last name for user: %s", target_user.id)
         selected_user.nameLast = target_user.nameLast
 
     if target_user.password:  # Update password if provided
+        logger.debug("Updating password for user: %s", target_user.id)
         if not validate_password(target_user.password):  # Validate password
             logger.warning(
                 "Failed to update user: %s (invalid password format)",

--- a/CentralServer/centralserver/routers/auth_routes.py
+++ b/CentralServer/centralserver/routers/auth_routes.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 from datetime import timedelta
 from typing import Annotated
 
@@ -73,12 +74,12 @@ async def create_new_user(
     return user
 
 
-@router.post("/token", response_model=JWTToken)
+@router.post("/token")
 async def request_access_token(
     data: Annotated[OAuth2PasswordRequestForm, Depends()],
     session: Annotated[Session, Depends(get_db_session)],
     request: Request,
-) -> JWTToken:
+) -> tuple[JWTToken, JWTToken]:
     """Get an access token for a user.
 
     Args:
@@ -87,7 +88,7 @@ async def request_access_token(
         request: The HTTP request object.
 
     Returns:
-        A JWT token object containing the access token and token type.
+        A JWT token and a refresh token.
 
     Raises:
         HTTPException: If the user cannot be authenticated.
@@ -110,7 +111,64 @@ async def request_access_token(
     session.commit()
     session.refresh(user)
 
+    return (
+        JWTToken(
+            uid=uuid.uuid4(),
+            access_token=create_access_token(
+                user.id,
+                timedelta(
+                    minutes=app_config.authentication.access_token_expire_minutes
+                ),
+            ),
+            token_type="bearer",
+        ),
+        JWTToken(
+            uid=uuid.uuid4(),
+            access_token=create_access_token(
+                user.id,
+                timedelta(
+                    minutes=app_config.authentication.refresh_token_expire_minutes
+                ),
+            ),
+            token_type="refresh",
+        ),
+    )
+
+
+@router.post("/refresh")
+async def refresh_access_token(
+    token: logged_in_dep,
+    session: Annotated[Session, Depends(get_db_session)],
+    request: Request,
+) -> JWTToken:
+    """Get an access token for a user.
+
+    Args:
+        token: The decoded JWT token of the logged-in user.
+        session: The database session.
+        request: The HTTP request object.
+
+    Returns:
+        A JWT token.
+
+    Raises:
+        HTTPException: If the user cannot be authenticated.
+    """
+
+    user: User | None = session.get(User, token.id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+
+    user.lastLoggedInTime = datetime.datetime.now(datetime.timezone.utc)
+    user.lastLoggedInIp = request.client.host if request.client else None
+    session.commit()
+    session.refresh(user)
+
     return JWTToken(
+        uid=uuid.uuid4(),
         access_token=create_access_token(
             user.id,
             timedelta(minutes=app_config.authentication.access_token_expire_minutes),

--- a/CentralServer/tests/test_user_management.py
+++ b/CentralServer/tests/test_user_management.py
@@ -32,9 +32,11 @@ def test_login_user_success():
 
     response = _request_access_token(Database.default_user, Database.default_password)
     assert response.status_code == 200
-    resp_data: dict[str, Any] = response.json()
-    assert type(resp_data["access_token"]) is str
-    assert resp_data["token_type"] == "bearer"
+    resp_data: list[dict[str, Any]] = response.json()
+    assert type(resp_data[0]["access_token"]) is str
+    assert resp_data[0]["token_type"] == "bearer"
+    assert type(resp_data[1]["access_token"]) is str
+    assert resp_data[1]["token_type"] == "refresh"
 
 
 def test_login_user_wrong_password():
@@ -75,7 +77,7 @@ def test_create_user_success():
     """Test creating a user successfully."""
 
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     for user in TEST_USERS.items():
         data: dict[str, Any] = {
             "username": user[0],
@@ -111,7 +113,7 @@ def test_view_user_success():
     """Test viewing a user's info successfully."""
 
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.get("/api/v1/users/get", headers=headers)
     assert response.status_code == 200
 
@@ -127,9 +129,9 @@ def test_view_user_fail():
     """Test failing to view a user's info."""
 
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     login2 = _request_access_token("testuser4", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     response = client.get("/api/v1/users/get", headers=headers)
     assert response.status_code == 200
 
@@ -145,7 +147,7 @@ def test_view_user_not_found():
     """Test viewing a user's info successfully."""
 
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.get("/api/v1/users/get", headers=headers)
     assert response.status_code == 200
     response2 = client.get(
@@ -159,7 +161,7 @@ def test_create_user_missing_required_field():
     """Test creating a user with a missing required field."""
 
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     data: dict[str, Any] = {
         "username": "testuser3",
         "password": "Password123",
@@ -180,7 +182,7 @@ def test_create_user_missing_username():
     """Test creating a user with a missing username."""
 
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.post(
         "/api/v1/auth/create",
         json={
@@ -195,7 +197,7 @@ def test_create_user_missing_username():
 
 def test_create_user_short_username():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.post(
         "/api/v1/auth/create",
         json={
@@ -213,7 +215,7 @@ def test_create_user_invalid_data_types():
     """Test creating a user with invalid data types."""
 
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.post(
         "/api/v1/auth/create",
         json={
@@ -231,7 +233,7 @@ def test_create_user_invalid_role_id():
     """Test creating a user with invalid role ID."""
 
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.post(
         "/api/v1/auth/create",
         json={
@@ -247,9 +249,9 @@ def test_create_user_invalid_role_id():
 
 def test_update_user():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     login2 = _request_access_token("testuser2", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     testuser_info = client.get(
         "/api/v1/users/me",
         headers=headers2,
@@ -279,7 +281,7 @@ def test_update_user():
 
 def test_update_user_no_permission():
     login = _request_access_token("testuser4", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.patch(
         "/api/v1/users/update",
         json={
@@ -296,7 +298,7 @@ def test_update_user_no_permission():
 
 def test_self_profile_logged_in():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -325,7 +327,7 @@ def test_self_profile_logged_out():
 
 def test_self_profile_update_name():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     myself = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -353,7 +355,7 @@ def test_self_profile_update_name():
 
 def test_self_profile_update_username_unchanged():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     myself = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -379,7 +381,7 @@ def test_self_profile_update_username_unchanged():
 
 def test_self_profile_update_username_taken():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     myself = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -400,7 +402,7 @@ def test_self_profile_update_username_taken():
 
 def test_self_profile_update_username_invalid():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     myself = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -421,7 +423,7 @@ def test_self_profile_update_username_invalid():
 
 def test_self_profile_update_email_valid():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     myself = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -444,7 +446,7 @@ def test_self_profile_update_email_valid():
 
 def test_self_profile_update_email_invalid():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     myself = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -465,7 +467,7 @@ def test_self_profile_update_email_invalid():
 
 def test_self_profile_update_password_weak():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     myself = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -483,7 +485,7 @@ def test_self_profile_update_password_weak():
 
 def test_self_profile_update_password_good():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     myself = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -507,7 +509,7 @@ def test_self_profile_update_password_good():
 
 def test_self_profile_update_invalid_id():
     login = _request_access_token("testuser3", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.patch(
         "/api/v1/users/me/update",
         json={
@@ -526,7 +528,7 @@ def test_self_profile_update_invalid_id():
 
 def test_view_all_roles():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.get(
         "/api/v1/auth/roles",
         headers=headers,
@@ -542,7 +544,7 @@ def test_view_all_roles():
 
 def test_view_all_roles_no_permission():
     login = _request_access_token("testuser4", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.get(
         "/api/v1/auth/roles",
         headers=headers,
@@ -553,9 +555,9 @@ def test_view_all_roles_no_permission():
 
 def test_update_user_role_no_permission():
     login = _request_access_token("testuser4", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     login2 = _request_access_token("testuser3", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers2,
@@ -574,7 +576,7 @@ def test_update_user_role_no_permission():
 
 def test_update_user_role_invalid_user():
     login = _request_access_token("testuser2", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     response = client.patch(
         "/api/v1/users/update/role",
         params={"userId": "blah", "roleId": 1},
@@ -586,9 +588,9 @@ def test_update_user_role_invalid_user():
 
 def test_update_user_role_invalid_role():
     login = _request_access_token("testuser2", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     login2 = _request_access_token("testuser3", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers2,
@@ -604,9 +606,9 @@ def test_update_user_role_invalid_role():
 
 def test_update_user_role():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     login2 = _request_access_token("testuser3", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers2,
@@ -625,11 +627,11 @@ def test_update_user_role():
 
 def test_update_user_role_last_superintendent():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     # Remove another superintendent
     login2 = _request_access_token("testuser3", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers2,
@@ -647,7 +649,7 @@ def test_update_user_role_last_superintendent():
 
     # Remove non-last superintendent
     login3 = _request_access_token("testuser1", "Password123")
-    headers3 = {"Authorization": f"Bearer {login3.json()['access_token']}"}
+    headers3 = {"Authorization": f"Bearer {login3.json()[0]['access_token']}"}
     user_info2 = client.get(
         "/api/v1/users/me",
         headers=headers3,
@@ -677,7 +679,7 @@ def test_update_user_role_last_superintendent():
 
 def test_deactivate_user_no_permission():
     login = _request_access_token("testuser4", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     response = client.patch(
         "/api/v1/users/update/deactivate",
@@ -692,7 +694,7 @@ def test_deactivate_user_no_permission():
 
 def test_deactivate_user_not_found():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     response = client.patch(
         "/api/v1/users/update/deactivate",
@@ -705,10 +707,10 @@ def test_deactivate_user_not_found():
 
 def test_deactivate_user_success():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     login2 = _request_access_token("testuser1", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers2,
@@ -724,7 +726,7 @@ def test_deactivate_user_success():
 
 def test_deactivate_user_last_superintendent():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     users = client.get(
         "/api/v1/users/get",
@@ -760,7 +762,7 @@ def test_deactivate_user_last_superintendent():
 
 def test_reactivate_user_no_permission():
     login = _request_access_token("testuser4", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     response = client.patch(
         "/api/v1/users/update/reactivate",
@@ -775,7 +777,7 @@ def test_reactivate_user_no_permission():
 
 def test_reactivate_user_not_found():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     response = client.patch(
         "/api/v1/users/update/reactivate",
@@ -788,10 +790,10 @@ def test_reactivate_user_not_found():
 
 def test_reactivate_user_success():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     login2 = _request_access_token("testuser1", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers2,
@@ -807,7 +809,7 @@ def test_reactivate_user_success():
 
 def test_force_update_user_info_no_permission():
     login = _request_access_token("testuser4", "Password123")
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     response = client.patch(
         "/api/v1/users/update/force",
@@ -823,7 +825,7 @@ def test_force_update_user_info_no_permission():
 
 def test_force_update_user_info_not_found():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     response = client.patch(
         "/api/v1/users/update/reactivate",
@@ -836,10 +838,10 @@ def test_force_update_user_info_not_found():
 
 def test_force_update_user_info_success():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     login2 = _request_access_token("testuser1", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers2,
@@ -858,7 +860,7 @@ def test_force_update_user_info_success():
 
 def test_update_user_avatar():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -882,7 +884,7 @@ def test_update_user_avatar():
 
 def test_get_user_avatar():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -903,7 +905,7 @@ def test_get_user_avatar():
 
 def test_delete_user_avatar():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
     user_info = client.get(
         "/api/v1/users/me",
         headers=headers,
@@ -920,10 +922,10 @@ def test_delete_user_avatar():
 
 def test_delete_user_avatar_no_current():
     login = _request_access_token(Database.default_user, Database.default_password)
-    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    headers = {"Authorization": f"Bearer {login.json()[0]['access_token']}"}
 
     login2 = _request_access_token("testuser1", "Password123")
-    headers2 = {"Authorization": f"Bearer {login2.json()['access_token']}"}
+    headers2 = {"Authorization": f"Bearer {login2.json()[0]['access_token']}"}
     user_info2 = client.get(
         "/api/v1/users/me",
         headers=headers2,

--- a/README.md
+++ b/README.md
@@ -299,6 +299,16 @@ containerized environment using Docker or Podman.
    }
    ```
 
+###### Central Server Environment Variables
+
+The following environment variables are used by the central server
+to further configure its behavior. These variables are optional.
+
+| Environment Variable             | Value           | Description                                |
+| -------------------------------- | --------------- | ------------------------------------------ |
+| `CENTRAL_SERVER_CONFIG_FILE`     | `./config.json` | The path of the configuration file to use. |
+| `CENTRAL_SERVER_CONFIG_ENCODING` | `utf-8`         | The encoding of the configuration file.    |
+
 #### Web Client
 
 The web client is written in TypeScript using the Next.js framework. It


### PR DESCRIPTION
- Introduced refresh tokens alongside access tokens in the authentication flow to enhance security and usability.
- Updated `/token` endpoint to return both access and refresh tokens.
- Added a new `/refresh` endpoint to generate new access tokens using refresh tokens.
- Updated tests to validate the new token structure and functionality.
- Improved logging for better traceability in user and token operations.